### PR TITLE
refactor: grunt, tests, less code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+bower_components
+dist
+*.log

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,0 +1,46 @@
+module.exports = (grunt) ->
+  require("load-grunt-tasks")(grunt)
+
+  grunt.initConfig(
+    title: "hoodie.angularjs"
+
+    bump: 
+      options: 
+        commitMessage: "chore: release v%VERSION%"
+        commitFiles: ['-a']
+        pushTo: "upstream"
+
+    concat:
+      options:
+        banner: 'Hoodie.extend(function(hoodie) {\n'
+        footer: '\n});'
+      dist: 
+        src: ['src/**/*.js']
+        dest: 'dist/<%= title %>.js'
+
+    shell:
+      release:
+        options: 
+          stdout: true
+        command: "mv <%= concat.dist.dest %> ./<%= title %>.js"
+
+     karma: 
+       options:
+         configFile: 'karma.conf.js'
+       continuous: 
+         singleRun: true
+       dev: 
+         background: true
+     
+     watch: 
+       dev: 
+         files: ['src/**/*.js', 'test/**/*.js']
+         tasks: ['karma:dev:run']
+  )
+
+  grunt.registerTask "build", ['concat', 'karma:continuous']
+  grunt.registerTask "dev", ['karma:dev:start', 'watch']
+  grunt.registerTask "release", ['build', 'shell', 'bump']
+
+  grunt.registerTask "default", "build"
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install
 
 `$ hoodie install angularjs` in your project folder will install the plugin. You need to load angular **BEFORE** hoodie.
 
-Initialize hoodie and load the plugin into angular. add the module name `hoodieModule` to your module array. Example:
+Initialize hoodie and load the plugin into angular. add the module name `hoodie` to your module array. Example:
 
 ```js
 // Init Hoodie
@@ -20,13 +20,19 @@ var hoodie  = new Hoodie()
 window.hoodie = hoodie;
 
 // Init Angular
-angular.module('worldDominationApp', ['hoodieModule'])
+angular.module('worldDominationApp', ['hoodie'])
 ```
 
 Services
 --------
 
-There are currently three services. hoodieAccount, hoodieStore and hoodieArray.
+There are currently four services. hoodie, hoodieAccount, hoodieStore and hoodieArray.
+
+### `hoodie`
+
+Use hoodieProvider.url(String) to configure your app's hoodie url at startup.  Scroll down for an example.
+
+You can then inject `hoodie` with dependency injection anywhere to get your plain old hoodie instance.  For more angular-friendly services, use the below.
 
 ### `hoodieAccount`
 
@@ -34,23 +40,26 @@ Use the same [API like plain hoodie](http://hood.ie/#docs). Use dependency Injec
 
 ### `hoodieStore`
 
-Use the same [API like plain hoodie](http://hood.ie/#docs). Use dependency Injection if you want to use this. I recomend
-you to use `hoodieArray`.
+Use the same [API like plain hoodie](http://hood.ie/#docs). Use dependency Injection if you want to use this. We recommend you to use `hoodieArray`.
 
 ### `hoodieArray`
 
-This is real nice. Add `hoodieArray` to your di-array. With the bind method you could bind an array to your hoodie store.
+Add `hoodieArray` to your di-array. With the bind method you could bind an array to your hoodie store.
 
 #### `hoodieArray.bind(scope, store[, hoodieStore])`
 
 * **scope**: the scope to bind with. Normaly `$scope`
 * **store**: the place were the store binds to.
-* **hoodieStore**: Not needed. the store name in hoodie. If unset, store will be used.
+* **hoodieStore**: Optional. the store name in hoodie. If unset, store will be used.
 
 Example:
 
 ```js
-angular.module('worldDominationApp', ['hoodieModule'])
+angular.module('worldDominationApp', ['hoodie'])
+
+.config(function(hoodieProvider) {
+  hoodieProivder.url('http://myhoodie.com/_api');
+})
 
 .controller('TodoCtrl', function ($scope, hoodieArray) {
 
@@ -69,3 +78,22 @@ angular.module('worldDominationApp', ['hoodieModule'])
   hoodieArray.bind($scope, 'todos', 'todo');
 });
 ```
+
+Development
+-----------
+
+We use [grunt](http://gruntjs.com) to build and [karma](http://karma-runner.github.io) to test, with [bower](http://bower.io) to install test dependencies.  To setup your development environment:
+
+- `grunt`
+- `npm install`
+- `bower install`
+
+Then, run `grunt` to build and test.  Run `grunt dev` to start the test server and test every save.  
+
+### Build & Release Process
+
+Run `grunt release`, which will do the following;
+- `grunt build` to concat the source files and wrap them in Hoodie.extend()
+- Move built file from `dist` to project root , using `grunt shell:release`.  We keep the concatenated file in dist by default so it cannot be accidentally commited.
+- Use `grunt bump` to commit, tag, and publish
+

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "hoodie-plugin-angularjs",
+  "homepage": "https://github.com/elmarburke/hoodie-plugin-angularjs",
+  "private": true,
+  "devDependencies": {
+    "angular-mocks": "1.2.5",
+    "angular": "1.2.5"
+  }
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,55 @@
+// Karma configuration
+// Generated on Tue Dec 17 2013 09:35:11 GMT-0500 (EST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '.',
+
+    // frameworks to use
+    frameworks: ['jasmine'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'bower_components/angular/angular.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'src/**/*.js',
+      'test/**/*.js'
+    ],
+
+    // list of files to exclude
+    exclude: [],
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['progress'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera (has to be installed with `npm install karma-opera-launcher`)
+    // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
+    // - PhantomJS
+    // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
+    browsers: ['Chrome'],
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 60000,
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -4,5 +4,29 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url" : "http://github.com:elmarburke/hoodie-plugin-angularjs.git"}
+    "url": "http://github.com:elmarburke/hoodie-plugin-angularjs.git"
+  },
+  "files": [
+    "hoodie.angularjs.js"
+  ],
+  "devDependencies": {
+    "grunt-conventional-changelog": "~1.0.0",
+    "grunt-shell": "~0.6.1",
+    "load-grunt-tasks": "~0.2.0",
+    "grunt": "~0.4.2",
+    "grunt-bump": "0.0.13",
+    "karma-script-launcher": "~0.1.0",
+    "karma-chrome-launcher": "~0.1.1",
+    "karma-html2js-preprocessor": "~0.1.0",
+    "karma-firefox-launcher": "~0.1.2",
+    "karma-jasmine": "~0.1.4",
+    "karma-coffee-preprocessor": "~0.1.1",
+    "requirejs": "~2.1.9",
+    "karma-requirejs": "~0.2.0",
+    "karma-phantomjs-launcher": "~0.1.1",
+    "karma": "~0.10.8",
+    "grunt-karma": "~0.6.2",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-concat": "~0.3.0"
+  }
 }

--- a/src/_main.js
+++ b/src/_main.js
@@ -1,0 +1,40 @@
+
+var hoodieModule = angular.module('hoodie', []);
+
+//Takes a callback that takes a single argument,
+//and returns a function that will $evalAsync and call that callack
+//$evalAsync will just make sure we don't have any $apply-conflicts
+function angularDigestFn($rootScope, callback) {
+  return function() {
+    var args = arguments;
+    $rootScope.$evalAsync(function() {
+      callback.apply(null, args);
+    });
+  };
+}
+
+//Takes a hoodie event, and will do the following when it fires in addition 
+//to calling the function:
+// 1. call $apply
+// 2. $emit('hoodie:evnetName') on the $rootScope
+function hoodieEventWrap(hoodieInstance, eventName, $rootScope,  fn) {
+  hoodieInstance.on(eventName, angularDigestFn($rootScope, function(eventData) {
+    fn(eventData);
+    $rootScope.$emit('hoodie:' + eventName, eventData);
+  }));
+}
+
+//Takes a hoodie function that returns a promise, and returns a function
+//that will call the hoodie function, then take that hoodie promise and
+//instead return a $q-promise and $apply when it returns
+function hoodiePromiseFnWrap(context, fnName, $q, $rootScope) {
+  return function() {
+    var args = arguments;
+    var deferred = $q.defer();
+    context[fnName].apply(context, args).then(
+      angularDigestFn($rootScope, deferred.resolve),
+      angularDigestFn($rootScope, deferred.reject)
+    );
+    return deferred.promise;
+  };
+}

--- a/src/hoodieAccount.js
+++ b/src/hoodieAccount.js
@@ -1,0 +1,40 @@
+
+hoodieModule.service('hoodieAcount', ['$rootScope', 'hoodie', '$q',
+function($rootScope, hoodie, $q) {
+  var service = this;
+
+  //Wrap hoodie fns to turn hoodie promises into angular
+  angular.forEach([
+    'signUp',
+    'signIn',
+    'signOut',
+    'changePassword',
+    'changeUsername',
+    'resetPassword',
+    'destroy'
+  ], function(fnName) {
+    service[fnName] = hoodiePromiseFnWrap(hoodie.account, fnName, $q, $rootScope);
+  });
+
+  // listen for account events
+  angular.forEach([
+    // user has signed up (this also triggers the authenticated event, see below)
+    'signup',
+    // user has signed in (this also triggers the authenticated event, see below)
+    'signin',
+    // user has signed out
+    'signout',
+    // user has re-authenticated after their session timed out 
+    // (this does _not_ trigger the signin event)
+    'authenticated',
+    // user's session has timed out. This means the user is still signed in locally, 
+    // but Hoodie cannot sync remotely, so the user must sign in again
+    'unauthenticated'
+  ], function(eventName) {
+    hoodieEventWrap(hoodie.account, eventName, $rootScope, function(username) {
+      service.username = username;
+    });
+  });
+
+  this.username = hoodie.account.username;
+}]);

--- a/src/hoodieArray.js
+++ b/src/hoodieArray.js
@@ -1,0 +1,108 @@
+hoodieModule.service('hoodieArray', ['$rootScope', 'hoodieStore',
+function($rootScope, hoodieStore) {
+
+  this.bind = function ($scope, key, hoodieKey) {
+
+    hoodieKey = hoodieKey || key;
+
+    $scope.$watch(key, function (newValue, oldValue) {
+      if (newValue === oldValue || !angular.isArray(newValue) || !angular.isArray(oldValue)) {
+        // Init
+        hoodieStore.findAll(hoodieKey)
+        .then(function (data) {
+          $scope[key] = data;
+        });
+      } else {
+
+        var delta = getDelta(oldValue, newValue, isEqual);
+        var item;
+        var key;
+
+        // first, add new items
+        for (key in delta.added) {
+          item = delta.added[key];
+          hoodieStore.add(hoodieKey, item);
+        }
+
+        // then, the changed items
+        for (key in delta.changed) {
+          item = delta.changed[key];
+          hoodieStore.update(hoodieKey, item.id, item);
+        }
+
+        // Last, lets delete items
+        for (key in delta.deleted) {
+          item = delta.deleted[key];
+          hoodieStore.remove(hoodieKey, item.id);
+        }
+
+      }
+    }, true);
+
+    hoodie.store.on('change:' + hoodieKey, function (event, changedObject) {
+      hoodieStore.findAll(hoodieKey)
+      .then(function (data) {
+        $scope[key] = data;
+      });
+    });
+
+
+  };
+}]);
+
+function arrayObjectIndexOf(myArray, searchTerm, property) {
+  for (var i = 0, len = myArray.length; i < len; i++) {
+    if (myArray[i][property] === searchTerm) return i;
+  }
+  return -1;
+}
+
+/**
+ * Creates a map out of an array be choosing what property to key by
+ * @param {object[]} array Array that will be converted into a map
+ * @param {string} prop Name of property to key by
+ * @return {object} The mapped array. Example:
+ *     mapFromArray([{a:1,b:2}, {a:3,b:4}], 'a')
+ *     returns {1: {a:1,b:2}, 3: {a:3,b:4}}
+ */
+function mapFromArray(array, prop) {
+  var map = {};
+  for (var i = 0; i < array.length; i++) {
+    map[ array[i][prop] ] = array[i];
+  }
+  return map;
+}
+
+function isEqual(a, b) {
+  return a.title === b.title && a.type === b.type;
+}
+
+/**
+ * @param {object[]} o old array of objects
+ * @param {object[]} n new array of objects
+ * @param {object} An object with changes
+ */
+function getDelta(o, n, comparator) {
+  var delta = {
+    added: [],
+    deleted: [],
+    changed: []
+  };
+  var mapO = mapFromArray(o, 'id');
+  var mapN = mapFromArray(n, 'id');
+  var id;
+  for (id in mapO) {
+    if (!mapN.hasOwnProperty(id)) {
+      delta.deleted.push(mapO[id]);
+    } else if (!comparator(mapN[id], mapO[id])) {
+      delta.changed.push(mapN[id]);
+    }
+  }
+
+  for (id in mapN) {
+    if (!mapO.hasOwnProperty(id)) {
+      delta.added.push(mapN[id]);
+    }
+  }
+  return delta;
+}

--- a/src/hoodieProvider.js
+++ b/src/hoodieProvider.js
@@ -1,0 +1,18 @@
+var HOODIE_URL_ERROR = "No url for hoodie set! Please set the hoodie url using hoodieProvider. Example: \n  myApp.config(function(hoodieProvider) {\n    hoodieProvider.url('http://myapp.dev/_api'); });  \n  });";
+hoodieModule.provider('hoodie', [function() {
+  var hoodieUrl;
+  this.url = function(url) {
+    if (arguments.length) {
+      hoodieUrl = url;
+    }
+    return url;
+  };
+
+  this.$get = function() {
+    if (!hoodieUrl) {
+      throw new Error(HOODIE_URL_ERROR);
+    }
+    return new Hoodie(hoodieUrl);
+  };
+
+}]);

--- a/src/hoodieStore.js
+++ b/src/hoodieStore.js
@@ -1,0 +1,47 @@
+
+hoodieModule.service('hoodieStore', ['$rootScope', '$q', 'hoodie', 
+function($rootScope, $q, hoodie) {
+  var service = this;
+
+  angular.forEach([
+    'add',
+    'update',
+    'find',
+    'findAll',
+    'remove',
+    'removeAll'
+  ], function(fnName) {
+    service[fnName] = hoodiePromiseFnWrap(hoodie.store, 'add', $q, $rootScope);
+  });
+
+  service.findAll()
+  .then(function (data) {
+    data.forEach(function (item) {
+      var type = item.type;
+      service[type] = service[type] || [];
+      service[type].push(item);
+    });
+  });
+
+  // write custom wrapper here, it's more complicated
+  // Events
+  hoodie.store.on('change', function (event, changedObject) {
+    $rootScope.$evalAsync(function() {
+      var type = changedObject.type;
+      var id = changedObject.id;
+
+      $rootScope.$emit(event, changedObject);
+      $rootScope.$emit('change', event, changedObject);
+      $rootScope.$emit(event + ':' + type, changedObject);
+      $rootScope.$emit('change' + ':' + type, event, changedObject);
+      $rootScope.$emit(event + ':' + type + ':' + id, changedObject);
+      $rootScope.$emit('change' + ':' + type + ':' + id, event, changedObject);
+
+      service.findAll(type)
+      .then(function (data) {
+        service[type] = data;
+      });
+    });
+  });
+
+}]);

--- a/test/hoodieArray.spec.js
+++ b/test/hoodieArray.spec.js
@@ -1,0 +1,5 @@
+describe('hoodieArray', function() {
+  it('should work', function() {
+    console.warn('TODO: test hoodieArray');
+  });
+});

--- a/test/hoodieProvider.spec.js
+++ b/test/hoodieProvider.spec.js
@@ -1,0 +1,22 @@
+describe('hoodieProvider', function() {
+  beforeEach(module('hoodie'));
+
+  it('should error if no url set', function() {
+    window.Hoodie = function(){};
+    expect(function() {
+      inject(function(hoodie) {
+      });
+    }).toThrow(HOODIE_URL_ERROR);
+  });
+
+  it('should return hoodie if url set',function() {
+    module('hoodie', function(hoodieProvider) {
+      hoodieProvider.url('myhood.com');
+    });
+    window.Hoodie = jasmine.createSpy('Hoodie');
+    inject(function(hoodie) {
+      expect(Hoodie).toHaveBeenCalledWith('myhood.com');
+      expect(hoodie instanceof Hoodie).toBe(true);
+    });
+  });
+});

--- a/test/testUtils.spec.js
+++ b/test/testUtils.spec.js
@@ -1,0 +1,109 @@
+describe('utils', function() {
+
+  describe('angularDigestFn', function() {
+
+    it('should evalAsync then call a callback with arguments', inject(function($rootScope, $timeout) {
+      var spy = jasmine.createSpy();
+      var fn = angularDigestFn($rootScope, spy);
+      fn('a', 'b', 'c');
+      expect(spy).not.toHaveBeenCalled();
+      //evalAsync creates a timeout if no digest is in progress already
+      $timeout.flush();
+      expect(spy).toHaveBeenCalledWith('a','b','c');
+    }));
+
+  });
+
+  describe('hoodiePromiseFnWrap', function() {
+
+    var myObject, successSpy, errorSpy, myWrappedFn;
+    beforeEach(inject(function($q, $rootScope) {
+      //We'l just create a fake objcet that returns a really fake mock-promise
+      //implementation.
+      //If we call myObject.promiseFn with success, it will call success promise
+      //If we call it with error, it will do the error promise
+      myObject = {
+        promiseFn: function(arg) {
+          expect(this).toBe(myObject);
+          return {
+            then: function(success, error) {
+              if (arg === 'error') { 
+                error(arg);
+              } else { 
+                success(arg);
+              }
+            }
+          };
+        }
+      };
+      spyOn(myObject, 'promiseFn').andCallThrough();
+      successSpy = jasmine.createSpy('success');
+      errorSpy = jasmine.createSpy('error');
+      myWrappedFn = hoodiePromiseFnWrap(myObject, 'promiseFn', $q, $rootScope);
+    }));
+
+    it('should call success promise and digest', inject(function($timeout) {
+      myWrappedFn('success').then(successSpy, errorSpy);
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      $timeout.flush();
+      expect(successSpy).toHaveBeenCalledWith('success');
+      expect(errorSpy).not.toHaveBeenCalled();
+    }));
+    it('should call error promise and digest', inject(function($timeout) {
+      myWrappedFn('error').then(successSpy, errorSpy);
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      
+      $timeout.flush();
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith('error');
+    }));
+
+  });
+
+
+  describe('hoodieEventWrap', function() {
+    var hoodieInstance, fireHoodieEvent;
+    beforeEach(function() {
+      hoodieEvents = {};
+      hoodieInstance = {
+        on: function(eventName, callback) {
+          hoodieEvents[eventName] = callback;
+        }
+      };
+      fireHoodieEvent = function(eventName, data1) {
+        hoodieEvents[eventName](data1);
+      };
+    });
+
+    it('should wrap a hoodie event, call cb, and digest', inject(function($rootScope, $timeout) {
+      var callbackSpy = jasmine.createSpy('callback');
+      spyOn($rootScope, '$emit');
+
+      hoodieEventWrap(hoodieInstance, 'bananaEvent', $rootScope, callbackSpy);
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect($rootScope.$emit).not.toHaveBeenCalled();
+
+      fireHoodieEvent('bananaEvent', 'monkey data');
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect($rootScope.$emit).not.toHaveBeenCalled();
+
+      $timeout.flush();
+      expect(callbackSpy).toHaveBeenCalledWith('monkey data');
+      expect($rootScope.$emit).toHaveBeenCalledWith('hoodie:bananaEvent', 'monkey data');
+
+      //see if it works multiple times
+      callbackSpy.reset();
+      $rootScope.$emit.reset();
+
+      fireHoodieEvent('bananaEvent', 'monkey data');
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect($rootScope.$emit).not.toHaveBeenCalled();
+      $timeout.flush();
+      expect(callbackSpy).toHaveBeenCalledWith('monkey data');
+      expect($rootScope.$emit).toHaveBeenCalledWith('hoodie:bananaEvent', 'monkey data');
+    }));
+  });
+});


### PR DESCRIPTION
Main changes:
1. Rename agular module from `hoodieModule` to `hoodie` - this is more conventional angular.
2. Add hoodieProvider, with function hoodieProvider.url, and service hoodie which just returns naked hoodie instance
3. Factor out most of the work for wrapping angular things into utility functions
4. Split up source into multiple files, add tests with access to the helper functions
5. Create grunt task to concat files and wrap them with Hoodie.extend()
6. Add tests for util functions
7. Add TODOs for tests for hoodieArray, hoodieStore, and hoodieAccount
8. In package.json, export only the main file

README is updated with dev instructions, and slightly modded documentation.
