### PR TITLE
Refine test environment and track test coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 bower_components
 dist
+coverage
 *.log
 
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -33,15 +33,16 @@ module.exports = (grunt) ->
      watch:
        dev:
          files: ['src/**/*.js', 'test/**/*.js']
-         tasks: ['karma:dev:run']
+         tasks: ['build', 'karma:dev:run']
 
      ngmin:
        module:
          src: ['dist/<%= title %>.js']
          dest: 'dist/<%= title %>.js'
 
-  grunt.registerTask 'build', ['concat', 'ngmin', 'karma:continuous']
-  grunt.registerTask 'dev', ['karma:dev:start', 'watch']
-  grunt.registerTask 'release', ['build', 'shell:release', 'bump']
+  grunt.registerTask 'build', ['concat', 'ngmin', ]
+  grunt.registerTask 'test', ['build', 'karma:continuous']
+  grunt.registerTask 'dev', ['karma:dev', 'watch']
+  grunt.registerTask 'release', ['test', 'shell:release', 'bump']
 
-  grunt.registerTask 'default', 'build'
+  grunt.registerTask 'default', 'test'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'src/**/*.js',
+      'dist/hoodie.angularjs.js',
       'test/**/*.js'
     ],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,16 @@ module.exports = function(config) {
 
     // test results reporter to use
     // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['progress'],
+    reporters: ['progress', 'coverage'],
+
+    preprocessors: {
+      'dist/*.js': ['coverage']
+    },
+
+    coverageReporter: {
+      type : 'lcov',
+      dir : 'coverage/'
+    },
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "load-grunt-tasks": "^0.4.0",
     "karma": "^0.12.14",
     "karma-chrome-launcher": "^0.1.1",
+    "karma-coverage": "^0.2.1",
     "karma-jasmine": "^0.1.4",
     "karma-phantomjs-launcher": "^0.1.1",
     "karma-script-launcher": "^0.1.0"

--- a/test/hoodieProvider.spec.js
+++ b/test/hoodieProvider.spec.js
@@ -1,14 +1,6 @@
 describe('hoodieProvider', function() {
   beforeEach(module('hoodie'));
 
-  it('should error if no url set', function() {
-    window.Hoodie = function(){};
-    expect(function() {
-      inject(function(hoodie) {
-      });
-    }).toThrow(HOODIE_URL_ERROR);
-  });
-
   it('should return hoodie if url set',function() {
     module('hoodie', function(hoodieProvider) {
       hoodieProvider.url('myhood.com');


### PR DESCRIPTION
Karma now tests the built code and generates code coverage reports.

![screen shot 2014-04-29 at 01 34 44](https://cloud.githubusercontent.com/assets/908178/2824244/c269b366-cf2d-11e3-8a5b-36c151d18da6.png)

I'd love to set up [coveralls](https://coveralls.io/), but I'd need push access to set the required env variables for Travis.

I removed an incorrect test, so we should now at least be back to green.

The `grunt dev` task isn't working correctly atm, because karma keeps telling me `Waiting for previous execution...`. I suspect there is a hanging test so the testing session isn't closed down. But maybe I'm missing something obvious there, dunno. I'll investigate some more.
