### PR TITLE
fix(account): set username to undefined on signout

### DIFF
--- a/src/hoodieAccount.js
+++ b/src/hoodieAccount.js
@@ -23,8 +23,6 @@ angular.module('hoodie')
       'signup',
       // user has signed in (this also triggers the authenticated event, see below)
       'signin',
-      // user has signed out
-      'signout',
       // user has re-authenticated after their session timed out
       // (this does _not_ trigger the signin event)
       'authenticated',
@@ -35,7 +33,7 @@ angular.module('hoodie')
 
       hoodie.account.on(eventName, function (username) {
         $rootScope.$apply(function () {
-          service.username = username;
+	  service.username = eventName === 'signout' ? undefined : username;
         });
         $rootScope.$emit('hoodie:' + eventName, arguments);
       });


### PR DESCRIPTION
Fixes #37.

I was unable to add tests or run the existing tests against this change, so don't merge right away! Neither Grunt nor Gulp ran without errors, I couldn't test. I ran `npm install` and `bower install` and this is the output I get:

``` bash
$ grunt
Running "concat:dist" (concat) task
File "dist/hoodie.angularjs.js" created.

Running "ngmin:module" (ngmin) task
ngminifying dist/hoodie.angularjs.js

Running "karma:continuous" (karma) task
WARN [reporter]: Can not load "coverage", it is not registered!
  Perhaps you are missing some plugin?
INFO [karma]: Karma v0.10.10 server started at http://localhost:9876/
INFO [launcher]: Starting browser PhantomJS
WARN [watcher]: Pattern "/Users/djpfahler/localhost/hoodie-plugin-angularjs/bower_components/jquery/dist/jquery.js" does not match any file.
WARN [watcher]: Pattern "/Users/djpfahler/localhost/hoodie-plugin-angularjs/bower_components/hoodie/dist/hoodie.js" does not match any file.
WARN [watcher]: Pattern "/Users/djpfahler/localhost/hoodie-plugin-angularjs/bower_components/angular/angular.js" does not match any file.
WARN [watcher]: Pattern "/Users/djpfahler/localhost/hoodie-plugin-angularjs/bower_components/angular-mocks/angular-mocks.js" does not match any file.
WARN [preprocess]: Can not load "coverage", it is not registered!
  Perhaps you are missing some plugin?
INFO [PhantomJS 1.9.7 (Mac OS X)]: Connected on socket LhTAT4DEZeP8yjy7Om0a
PhantomJS 1.9.7 (Mac OS X) ERROR
    ReferenceError: Can't find variable: angular
    at /Users/djpfahler/localhost/hoodie-plugin-angularjs/src/_main.js:1
PhantomJS 1.9.7 (Mac OS X) ERROR
    ReferenceError: Can't find variable: angular
    at /Users/djpfahler/localhost/hoodie-plugin-angularjs/src/hoodieAccount.js:1
PhantomJS 1.9.7 (Mac OS X) ERROR
    ReferenceError: Can't find variable: angular
    at /Users/djpfahler/localhost/hoodie-plugin-angularjs/src/hoodieArray.js:1
PhantomJS 1.9.7 (Mac OS X) ERROR
    ReferenceError: Can't find variable: angular
    at /Users/djpfahler/localhost/hoodie-plugin-angularjs/src/hoodieProvider.js:1
PhantomJS 1.9.7 (Mac OS X) ERROR
    ReferenceError: Can't find variable: angular
    at /Users/djpfahler/localhost/hoodie-plugin-angularjs/src/hoodieStore.js:1
PhantomJS 1.9.7 (Mac OS X): Executed 0 of 0 ERROR (0.019 secs / 0 secs)
Warning: Task "karma:continuous" failed. Use --force to continue.
```

``` bash
$ gulp

module.js:340
    throw err;
          ^
Error: Cannot find module 'gulp-bump'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/djpfahler/localhost/hoodie-plugin-angularjs/Gulpfile.js:7:10)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Liftoff.handleArguments (/Users/djpfahler/.nvm/v0.10.29/lib/node_modules/gulp/bin/gulp.js:108:3)
    at Liftoff.launch (/Users/djpfahler/.nvm/v0.10.29/lib/node_modules/gulp/node_modules/liftoff/index.js:140:6)
    at Object.<anonymous> (/Users/djpfahler/.nvm/v0.10.29/lib/node_modules/gulp/bin/gulp.js:59:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
