### PR TITLE
Loading the /_api/_files/hoodie.js is the correct way

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ A little bit about the plugin.
 
 ```html
 <script src="jquery.js"></script>
-<script src="hoodie.js"></script>
 <script src="angular.js"></script>
-<script src="hoodie-plugin-angularjs.js"></script>
+<script src="/_api/_files/hoodie.js"></script>
 ```
 
 Load the `hoodie` module into angular and initialize hoodie.


### PR DESCRIPTION
When loading like so: `<script src="/_api/_files/hoodie.js"></script>`
there is no need to load also hoodie-plugin-angularjs.js since it is loaded atomatically by the `<script src="/_api/_files/hoodie.js"></script>`
and so need to load angular before that.

have a look at: https://github.com/hoodiehq/hoodie.js/issues/404

Idanb11
